### PR TITLE
Fix small typo on ecs error handling example comment.

### DIFF
--- a/examples/ecs/error_handling.rs
+++ b/examples/ecs/error_handling.rs
@@ -15,7 +15,7 @@ fn main() {
     //
     // We can change this by setting a custom error handler, which applies to the entire app
     // (you can also set it for specific `World`s).
-    // Here we it using one of the built-in error handlers.
+    // Here we are using one of the built-in error handlers.
     // Bevy provides built-in handlers for `panic`, `error`, `warn`, `info`,
     // `debug`, `trace` and `ignore`.
     app.set_error_handler(warn);


### PR DESCRIPTION
Fixed small typo in comments

# Objective

- Fixes a small typo on error handling example comments.

## Solution

N/A

## Testing

N/A